### PR TITLE
Set shared plugin data with theemo references

### DIFF
--- a/packages/figma-theemo/src/commands/collect-references.ts
+++ b/packages/figma-theemo/src/commands/collect-references.ts
@@ -1,5 +1,6 @@
 import Command from './command';
 import { STYLES } from '../styles/types';
+import { NAMESPACE } from '../config';
 
 export default class CollectReferencesCommand extends Command {
   NAME = 'collect-references';
@@ -24,6 +25,7 @@ export default class CollectReferencesCommand extends Command {
       nodes
     };
 
+    figma.root.setSharedPluginData(NAMESPACE, 'references-data', JSON.stringify(data));
     this.emitter.sendEvent('references-collected', data);
   }
 


### PR DESCRIPTION
Being able to access theemo references without fetching JSONBin API has been a lifesaver, I've been doing that for months with a modified Figma Theemo copy.

There can be a lot of use cases, mine is the integration with "Automator" plugin — thanks to the references I save with setSharedPluginData I'm able to automatically write styles' name and their origins.

https://user-images.githubusercontent.com/35091482/181370531-be746023-f8be-420d-a0c1-6cfa244e1df4.mp4