### PR TITLE
Remove Lexer Defaults

### DIFF
--- a/packages/@theemo/sync/src/lexer/config.ts
+++ b/packages/@theemo/sync/src/lexer/config.ts
@@ -11,18 +11,14 @@ export interface LexerConfig {
    *
    * @example
    *
-   * This is the default normalize method:
+   * Here is how to remove any whitespace from token names:
    *
-   * ```js
+   * ```ts
    * normalizeToken(token: Token): Token {
-   *  const normalized = { ...token };
-   *
-   *  normalized.name = normalized.name.replace(/\s/g, '');
-   *  if (normalized.reference) {
-   *    normalized.reference = normalized.reference.replace(/\s/g, '');
-   *  }
-   *
-   *  return normalized;
+   *   return {
+   *     ...token,
+   *     name: normalized.name.replace(/\s/g, '')
+   *   };
    * }
    * ```
    */
@@ -60,21 +56,4 @@ export interface LexerConfig {
       classified: TokenCollection;
     }
   ) => boolean;
-}
-
-const DEFAULT_LEXER_CONFIG = {
-  normalizeToken(token: Token): Token {
-    const normalized = { ...token };
-
-    normalized.name = normalized.name.replace(/\s/g, '');
-
-    return normalized;
-  }
-};
-
-export function getLexerConfig(config: LexerConfig): LexerConfig {
-  return {
-    ...DEFAULT_LEXER_CONFIG,
-    ...config
-  };
 }

--- a/packages/@theemo/sync/src/lexer/index.ts
+++ b/packages/@theemo/sync/src/lexer/index.ts
@@ -1,7 +1,5 @@
 import { TokenCollection } from '@theemo/tokens';
 
-import { getLexerConfig } from './config.js';
-
 import type { LexerConfig } from './config.js';
 import type { Token } from '@theemo/tokens';
 
@@ -12,7 +10,7 @@ export class Lexer {
   private classifiedTokens: TokenCollection = new TokenCollection();
 
   constructor(config: LexerConfig) {
-    this.config = getLexerConfig(config);
+    this.config = config;
   }
 
   analyze(tokens: TokenCollection): TokenCollection {


### PR DESCRIPTION
This wasn't a reasonable default to remove whitespaces from a token name. Defaults were also never exported. So removing them is the smarter call.